### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stvnksslr/qlite/compare/v0.1.0...v0.1.1) - 2025-09-08
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/stvnksslr/qlite/releases/tag/v0.1.0) - 2025-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "qlite"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "askama",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qlite"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A sqs drop in replacement for local or cicd development"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `qlite`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/stvnksslr/qlite/compare/v0.1.0...v0.1.1) - 2025-09-08

### Other

- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).